### PR TITLE
A few updates to help this play nice with cfpb.github.io

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -14,7 +14,7 @@
     </style>
   </head>
   <body>
-    <h1>{{ page.title }}</h1
+    <h1>{{ page.title }}</h1>
 
     {{ content }}
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,7 @@
     <title>{{ page.title }}</title>
     <link rel="stylesheet" href="//cfpb.github.io/css/site.css">
     <style>
-      body { padding: 25px; }
+      body { max-width: 48em; padding: 1.5em; }
       li ol { margin-left: 3em; counter-reset: list; }
       li { list-style: decimal; text-transform: uppercase; }
       li li { list-style: none;  position: relative; text-transform: none;  }

--- a/cfpb-source-code-policy.md
+++ b/cfpb-source-code-policy.md
@@ -2,7 +2,6 @@
 layout: page
 title: CFPB Source Code Policy
 permalink: /
-assetpath: ../
 ---
 
 1. Use of external open source software

--- a/cfpb-source-code-policy.md
+++ b/cfpb-source-code-policy.md
@@ -2,6 +2,7 @@
 layout: page
 title: CFPB Source Code Policy
 permalink: /
+assetpath: ../
 ---
 
 1. Use of external open source software

--- a/cfpb-source-code-policy.md
+++ b/cfpb-source-code-policy.md
@@ -2,6 +2,7 @@
 layout: default
 title: CFPB Source Code Policy
 permalink: /
+assetpath: ../../
 ---
 
 1. Use of external open source software

--- a/cfpb-source-code-policy.md
+++ b/cfpb-source-code-policy.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: page
 title: CFPB Source Code Policy
 permalink: /
 assetpath: ../

--- a/cfpb-source-code-policy.md
+++ b/cfpb-source-code-policy.md
@@ -2,7 +2,7 @@
 layout: default
 title: CFPB Source Code Policy
 permalink: /
-assetpath: ../../
+assetpath: ../
 ---
 
 1. Use of external open source software


### PR DESCRIPTION
- Renames layout to `page` to match what it needs to be in cfpb.github.io
- Adds the `assetpath` property to make sure it can correctly find the CSS when submoduled into cfpb.github.io
- Gives the `body` a max-width for sane line-lengths when viewing in THIS repo.
