### PR TITLE
Fixed type in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 > All contributions to this project will be released under the CC0
 > dedication. By submitting a pull request, or filing a bug, issue, or 
 > feature-request you are agreeing to comply with this waiver of copyright interest.
-> Details can be found in our [TERMS](TERMS.md) and [LICENCE](LICENSE).
+> Details can be found in our [TERMS](TERMS.md) and [LICENSE](LICENSE).
 
 
 There are two primary ways to help: 


### PR DESCRIPTION
Found typo when looking to update GSA OSS repo.  Also noticed that TERMS and LICENSE links in "()" are slightly different.  One includes ".md" extension and one does not.  They don't need the extension but it isn't affecting performance.  Just a consistency issue.

Cheers!
Joe, OSS Evangelist at GSA